### PR TITLE
Supressing org.komamitsu.logging package logging using logback xml

### DIFF
--- a/complete/src/main/resources/logback.xml
+++ b/complete/src/main/resources/logback.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <logger name="org.komamitsu.fluency" level="OFF">
+    </logger>
+</configuration>


### PR DESCRIPTION
@itaiMona FYI - adding this file in this location supresses the logging coming from fluency, check it...

I will investigate how to interleave it in mona client dependency so it works...